### PR TITLE
Fix typo in query debug log

### DIFF
--- a/SourceWatch/query.py
+++ b/SourceWatch/query.py
@@ -46,7 +46,7 @@ class Query:
 
     def _receive(self, packet_buffer={}):
         response = self._connection.recv(PACKET_SIZE)
-        self.logger.debug("Recieved: %s", response)
+        self.logger.debug("Received: %s", response)
         packet = SteamPacketBuffer(response)
         respone_format = packet.read_long()
 


### PR DESCRIPTION
## Summary
- correct typo in `_receive` debug message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68586c03cf1c8323a518b770b2c9b684