### PR TITLE
Fix response parsing bug and add char helper methods

### DIFF
--- a/SourceWatch/buffer.py
+++ b/SourceWatch/buffer.py
@@ -36,6 +36,16 @@ class SteamPacketBuffer(io.BytesIO):
         """Write a 8 bit character or unsigned integer. From 0 to 255"""
         self.write(struct.pack("<B", value))
 
+    def read_char(self) -> str:
+        """Read a single character stored as one byte."""
+        return struct.unpack("<c", self.read(1))[0].decode("ascii")
+
+    def write_char(self, value: str):
+        """Write a single ASCII character as one byte."""
+        if len(value) != 1:
+            raise ValueError("write_char expects a single character")
+        self.write(struct.pack("<c", value.encode("ascii")))
+
     def read_short(self) -> int:
         """Read a 16 bit signed integer (2 bytes)."""
         return struct.unpack("<h", self.read(2))[0]

--- a/SourceWatch/packet.py
+++ b/SourceWatch/packet.py
@@ -102,6 +102,8 @@ class InfoResponse(ResponsePacket):
     RESPONSE_HEADER = 0x49  # 0x6D  Counter-Strike 1.6
 
     def result(self):
+        # Consume the header byte before parsing the actual payload
+        self.header
         info = {
             "server_protocol_version": self._buffer.read_byte(),
             "server_name": self._buffer.read_string(),
@@ -149,6 +151,8 @@ class InfoGoldSrcResponse(ResponsePacket):
     RESPONSE_HEADER = 0x6D
 
     def result(self):
+        # Consume the header byte before parsing the actual payload
+        self.header
         info = {
             "server_address": self._buffer.read_string(),
             "server_name": self._buffer.read_string(),
@@ -203,6 +207,8 @@ class RulesResponse(ResponsePacket):
     RESPONSE_HEADER = 0x45
 
     def result(self):
+        # Consume the header byte before parsing the actual payload
+        self.header
         rules = {}
         total_rules = self._buffer.read_short()
         for _ in range(total_rules):
@@ -220,6 +226,8 @@ class PlayersResponse(ResponsePacket):
     RESPONSE_HEADER = 0x44
 
     def result(self):
+        # Consume the header byte before parsing the actual payload
+        self.header
         total_players = self._buffer.read_byte()
         players = []
         for _ in range(total_players):

--- a/test/test_packet_responses.py
+++ b/test/test_packet_responses.py
@@ -1,0 +1,38 @@
+import unittest
+import SourceWatch
+from SourceWatch import buffer as buf_mod
+from SourceWatch import packet
+
+class TestPacketResponses(unittest.TestCase):
+    def _make_info_packet(self):
+        b = buf_mod.SteamPacketBuffer()
+        b.write_long(-1)  # SINGLE_PACKET_RESPONSE
+        b.write_byte(packet.InfoResponse.RESPONSE_HEADER)
+        b.write_byte(17)  # server protocol version
+        b.write_string('Test Server')
+        b.write_string('test_map')
+        b.write_string('test_dir')
+        b.write_string('Test Game')
+        b.write_short(10)
+        b.write_byte(1)
+        b.write_byte(10)
+        b.write_byte(0)
+        b.write_char('d')
+        b.write_char('l')
+        b.write_byte(0)
+        b.write_byte(1)
+        b.write_string('1.0')
+        b.write_byte(0)  # no extra data flags
+        # mimic Query._send behaviour
+        b.seek(0)
+        b.read_long()
+        return b
+
+    def test_info_response_parsing(self):
+        buf = self._make_info_packet()
+        resp = packet.InfoResponse(buf, 0)
+        data = resp.result()
+        self.assertEqual(data['info']['server_name'], 'Test Server')
+        self.assertEqual(data['info']['server_type'], 'd')
+        self.assertEqual(data['info']['server_os'], 'l')
+


### PR DESCRIPTION
## Summary
- add `read_char`/`write_char` helpers in `SteamPacketBuffer`
- consume the packet header before parsing all response packets
- add regression test for `InfoResponse`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68586a4037a88323b7f8fd2cfea25cc8